### PR TITLE
Remove muscle goal option

### DIFF
--- a/components/onboarding/GoalSelector.tsx
+++ b/components/onboarding/GoalSelector.tsx
@@ -22,17 +22,6 @@ const GoalSelector: React.FC<GoalSelectorProps> = ({ selected, onSelect }) => {
       ),
     },
     {
-      id: 'muscle',
-      title: 'Muscle',
-      description: 'Emphasis on muscle growth and definition',
-      icon: (isSelected: boolean) => (
-        <Zap 
-          size={28} 
-          color={isSelected ? theme.colors.primary : theme.colors.textLight} 
-        />
-      ),
-    },
-    {
       id: 'toning',
       title: 'Toning',
       description: 'Focus on sculpting and defining your physique',

--- a/components/plan/GoalSelector.tsx
+++ b/components/plan/GoalSelector.tsx
@@ -22,17 +22,6 @@ const GoalSelector: React.FC<GoalSelectorProps> = ({ selected, onSelect }) => {
       ),
     },
     {
-      id: 'muscle',
-      title: 'Muscle',
-      description: 'Emphasis on muscle growth and definition',
-      icon: (isSelected: boolean) => (
-        <Zap 
-          size={28} 
-          color={isSelected ? theme.colors.primary : theme.colors.textLight} 
-        />
-      ),
-    },
-    {
       id: 'toning',
       title: 'Toning',
       description: 'Focus on sculpting and defining your physique',

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -8,7 +8,7 @@ export interface UserProfile {
   equipment?: string[];
   daysPerWeek?: number;
   workoutDuration?: number;
-  goal?: 'strength' | 'toning' | 'muscle' | 'confidence';
+  goal?: 'strength' | 'toning' | 'confidence';
   settings?: {
     workoutReminders?: boolean;
     progressUpdates?: boolean;


### PR DESCRIPTION
## Summary
- remove the `muscle` goal choice from both goal selectors
- update user profile type accordingly

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844429b95748327919535085a77f800