### PR TITLE
Add 'Both' training location option

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -143,7 +143,12 @@ export default function ProfileScreen() {
             </View>
             <View style={styles.preferenceContent}>
               <Text style={styles.preferenceTitle}>Workout Location</Text>
-              <Text style={styles.preferenceValue}>{userProfile?.workoutLocation || 'Gym'}</Text>
+              <Text style={styles.preferenceValue}>
+                {userProfile?.workoutLocation
+                  ? userProfile.workoutLocation.charAt(0).toUpperCase() +
+                    userProfile.workoutLocation.slice(1)
+                  : 'Gym'}
+              </Text>
             </View>
             <ChevronRight size={20} color={theme.colors.textLight} />
           </View>

--- a/components/onboarding/LocationSelector.tsx
+++ b/components/onboarding/LocationSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { theme } from '@/constants/theme';
-import { Chrome as Home, Building2 } from 'lucide-react-native';
+import { Chrome as Home, Building2, Shuffle } from 'lucide-react-native';
 
 interface LocationSelectorProps {
   selected: string;
@@ -75,6 +75,37 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({
           Full range of equipment available
         </Text>
       </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[
+          styles.locationCard,
+          selected === 'both' && styles.selectedCard
+        ]}
+        onPress={() => onSelect('both')}
+      >
+        <View
+          style={[
+            styles.iconContainer,
+            selected === 'both' && styles.selectedIconContainer
+          ]}
+        >
+          <Shuffle
+            size={36}
+            color={selected === 'both' ? theme.colors.primary : theme.colors.textLight}
+          />
+        </View>
+        <Text
+          style={[
+            styles.locationTitle,
+            selected === 'both' && styles.selectedText
+          ]}
+        >
+          Both
+        </Text>
+        <Text style={styles.locationDescription}>
+          Mix of home and gym workouts
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 };
@@ -83,6 +114,7 @@ const styles = StyleSheet.create({
   container: {
     width: '100%',
     flexDirection: 'row',
+    flexWrap: 'wrap',
     justifyContent: 'space-between',
   },
   locationCard: {

--- a/components/plan/LocationSelector.tsx
+++ b/components/plan/LocationSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { theme } from '@/constants/theme';
-import { Chrome as Home, Building2 } from 'lucide-react-native';
+import { Chrome as Home, Building2, Shuffle } from 'lucide-react-native';
 
 interface LocationSelectorProps {
   selected: string;
@@ -75,6 +75,37 @@ const LocationSelector: React.FC<LocationSelectorProps> = ({
           Full range of equipment available
         </Text>
       </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[
+          styles.locationCard,
+          selected === 'both' && styles.selectedCard
+        ]}
+        onPress={() => onSelect('both')}
+      >
+        <View
+          style={[
+            styles.iconContainer,
+            selected === 'both' && styles.selectedIconContainer
+          ]}
+        >
+          <Shuffle
+            size={36}
+            color={selected === 'both' ? theme.colors.primary : theme.colors.textLight}
+          />
+        </View>
+        <Text
+          style={[
+            styles.locationTitle,
+            selected === 'both' && styles.selectedText
+          ]}
+        >
+          Both
+        </Text>
+        <Text style={styles.locationDescription}>
+          Mix of home and gym workouts
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 };
@@ -83,6 +114,7 @@ const styles = StyleSheet.create({
   container: {
     width: '100%',
     flexDirection: 'row',
+    flexWrap: 'wrap',
     justifyContent: 'space-between',
   },
   locationCard: {

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -4,7 +4,7 @@ export interface UserProfile {
   name?: string;
   avatar?: string;
   fitnessLevel?: 'beginner' | 'intermediate' | 'advanced';
-  workoutLocation?: 'home' | 'gym';
+  workoutLocation?: 'home' | 'gym' | 'both';
   equipment?: string[];
   daysPerWeek?: number;
   workoutDuration?: number;

--- a/utils/workoutPlanner.ts
+++ b/utils/workoutPlanner.ts
@@ -261,18 +261,24 @@ export function generateWorkoutPlan(userProfile: UserProfile): WorkoutPlan {
     
     // Get exercises for this workout
     let workoutExercises: Exercise[] = [];
-    
-    if (exerciseCategory in exercises[fitnessLevel][workoutLocation]) {
-      workoutExercises = [...exercises[fitnessLevel][workoutLocation][exerciseCategory]];
-      
-      // Adjust number of exercises based on duration
-      const targetExerciseCount = Math.floor(userProfile.workoutDuration / 10);
-      if (workoutExercises.length > targetExerciseCount) {
-        workoutExercises = workoutExercises.slice(0, targetExerciseCount);
-      }
+
+    if (workoutLocation === 'both') {
+      const gymExercises = exercises[fitnessLevel].gym[exerciseCategory] || [];
+      const homeExercises = exercises[fitnessLevel].home[exerciseCategory] || [];
+      workoutExercises = [...gymExercises, ...homeExercises];
+    } else if (exerciseCategory in exercises[fitnessLevel][workoutLocation]) {
+      workoutExercises = [
+        ...exercises[fitnessLevel][workoutLocation][exerciseCategory],
+      ];
     } else {
       // Fallback to full body if the specific split isn't available
       workoutExercises = [...exercises[fitnessLevel][workoutLocation].full];
+    }
+
+    // Adjust number of exercises based on duration
+    const targetExerciseCount = Math.floor(userProfile.workoutDuration / 10);
+    if (workoutExercises.length > targetExerciseCount) {
+      workoutExercises = workoutExercises.slice(0, targetExerciseCount);
     }
     
     // Create the workout


### PR DESCRIPTION
## Summary
- allow selection of `Both` for training location
- show `Both` option in plan and onboarding selectors
- show capitalized workout location on profile page
- support `both` option in user profile and workout planning logic

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684446d11b4883279dd52fa27139e1b8