### PR TITLE
Add 1-day option to DaysSelector

### DIFF
--- a/components/onboarding/DaysSelector.tsx
+++ b/components/onboarding/DaysSelector.tsx
@@ -8,8 +8,8 @@ interface DaysSelectorProps {
 }
 
 const DaysSelector: React.FC<DaysSelectorProps> = ({ selected, onSelect }) => {
-  // Days options from 2 to 6
-  const daysOptions = [2, 3, 4, 5, 6];
+  // Days options from 1 to 6
+  const daysOptions = [1, 2, 3, 4, 5, 6];
   
   return (
     <View style={styles.container}>
@@ -37,7 +37,7 @@ const DaysSelector: React.FC<DaysSelectorProps> = ({ selected, onSelect }) => {
       
       <View style={styles.descriptionContainer}>
         <Text style={styles.descriptionTitle}>
-          {selected} days per week
+          {selected} {selected === 1 ? 'day' : 'days'} per week
         </Text>
         <Text style={styles.descriptionText}>
           {selected <= 3 

--- a/components/plan/DaysSelector.tsx
+++ b/components/plan/DaysSelector.tsx
@@ -8,8 +8,8 @@ interface DaysSelectorProps {
 }
 
 const DaysSelector: React.FC<DaysSelectorProps> = ({ selected, onSelect }) => {
-  // Days options from 2 to 6
-  const daysOptions = [2, 3, 4, 5, 6];
+  // Days options from 1 to 6
+  const daysOptions = [1, 2, 3, 4, 5, 6];
   
   return (
     <View style={styles.container}>
@@ -37,7 +37,7 @@ const DaysSelector: React.FC<DaysSelectorProps> = ({ selected, onSelect }) => {
       
       <View style={styles.descriptionContainer}>
         <Text style={styles.descriptionTitle}>
-          {selected} days per week
+          {selected} {selected === 1 ? 'day' : 'days'} per week
         </Text>
         <Text style={styles.descriptionText}>
           {selected <= 3 


### PR DESCRIPTION
## Summary
- allow selecting 1 training day in DaysSelector
- show singular `day` when one day is chosen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444c7fcfc08327ae79a65f82d796d1