### PR TITLE
Add training focus selection step

### DIFF
--- a/app/plan/start.tsx
+++ b/app/plan/start.tsx
@@ -10,6 +10,7 @@ import GoalSelector from '@/components/plan/GoalSelector';
 import LocationSelector from '@/components/plan/LocationSelector';
 import DaysSelector from '@/components/plan/DaysSelector';
 import DurationSelector from '@/components/plan/DurationSelector';
+import FocusAreasSelector from '@/components/plan/FocusAreasSelector';
 import { ArrowLeft } from 'lucide-react-native';
 
 export default function PlanStartScreen() {
@@ -20,6 +21,7 @@ export default function PlanStartScreen() {
   const [planData, setPlanData] = useState({
     goal: '',
     location: '',
+    trainingFocus: [] as string[],
     daysPerWeek: 3,
     sessionDuration: 45,
   });
@@ -29,7 +31,7 @@ export default function PlanStartScreen() {
   };
   
   const handleNext = () => {
-    if (step < 3) {
+    if (step < 4) {
       setStep(step + 1);
     } else {
       completePlanSetup();
@@ -63,8 +65,10 @@ export default function PlanStartScreen() {
       case 1:
         return !planData.location;
       case 2:
-        return !planData.daysPerWeek;
+        return planData.trainingFocus.length === 0;
       case 3:
+        return !planData.daysPerWeek;
+      case 4:
         return !planData.sessionDuration;
       default:
         return false;
@@ -112,6 +116,19 @@ export default function PlanStartScreen() {
         
         {step === 2 && (
           <View style={styles.step}>
+            <Text style={styles.stepTitle}>What areas would you like to focus on?</Text>
+            <Text style={styles.stepDescription}>
+              Choose as many as you like — this helps us tailor your training.
+            </Text>
+            <FocusAreasSelector
+              selected={planData.trainingFocus}
+              onSelect={(areas) => updatePlanData('trainingFocus', areas)}
+            />
+          </View>
+        )}
+
+        {step === 3 && (
+          <View style={styles.step}>
             <Text style={styles.stepTitle}>How many days can you train?</Text>
             <Text style={styles.stepDescription}>
               Choose a schedule that fits your lifestyle.
@@ -122,8 +139,8 @@ export default function PlanStartScreen() {
             />
           </View>
         )}
-        
-        {step === 3 && (
+
+        {step === 4 && (
           <View style={styles.step}>
             <Text style={styles.stepTitle}>How long is each session?</Text>
             <Text style={styles.stepDescription}>
@@ -140,7 +157,7 @@ export default function PlanStartScreen() {
       
       <View style={styles.footer}>
         <Button
-          title={step === 3 ? "Create My Plan" : "Continue"}
+          title={step === 4 ? "Create My Plan" : "Continue"}
           onPress={handleNext}
           disabled={isNextDisabled()}
           style={styles.nextButton}

--- a/components/plan/FocusAreasSelector.tsx
+++ b/components/plan/FocusAreasSelector.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { theme } from '@/constants/theme';
+
+interface FocusAreasSelectorProps {
+  selected: string[];
+  onSelect: (areas: string[]) => void;
+}
+
+const FocusAreasSelector: React.FC<FocusAreasSelectorProps> = ({ selected, onSelect }) => {
+  const areas = [
+    { id: 'glutes_legs', title: 'Glutes and Legs' },
+    { id: 'upper_body', title: 'Upper Body (Arms, Shoulders, Back)' },
+    { id: 'core_abs', title: 'Core and Abs' },
+    { id: 'mobility', title: 'Mobility and Flexibility' },
+    { id: 'conditioning', title: 'Conditioning' },
+    { id: 'full_body', title: 'Full Body Strength' },
+  ];
+
+  const toggleArea = (id: string) => {
+    if (selected.includes(id)) {
+      onSelect(selected.filter(item => item !== id));
+    } else {
+      onSelect([...selected, id]);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {areas.map(area => {
+        const isSelected = selected.includes(area.id);
+        return (
+          <TouchableOpacity
+            key={area.id}
+            style={[styles.item, isSelected && styles.selectedItem]}
+            onPress={() => toggleArea(area.id)}
+          >
+            <Text style={[styles.title, isSelected && styles.selectedTitle]}>
+              {area.title}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  item: {
+    backgroundColor: theme.colors.white,
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: theme.colors.borderLight,
+  },
+  selectedItem: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.primaryExtraLight,
+  },
+  title: {
+    fontFamily: 'Outfit-SemiBold',
+    fontSize: 18,
+    color: theme.colors.text,
+    textAlign: 'center',
+  },
+  selectedTitle: {
+    color: theme.colors.primary,
+  },
+});
+
+export default FocusAreasSelector;


### PR DESCRIPTION
## Summary
- add `FocusAreasSelector` for multi-select focus areas
- store training focus in plan state and add new step to create plan

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844517aae588327a6ee34c2a350b883