### PR TITLE
Fix weekend workout detection

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,8 +17,9 @@ export default function HomeScreen() {
   const { currentPlan, workoutHistory } = useWorkoutStore();
 
   const today = new Date();
+  const todayDay = today.getDay();
   const todayWorkout = currentPlan?.workouts?.find(
-    workout => workout.day === today.getDay()
+    workout => Number(workout.day) === todayDay
   );
 
   const startWorkout = () => {

--- a/app/(tabs)/plan.tsx
+++ b/app/(tabs)/plan.tsx
@@ -30,7 +30,9 @@ export default function PlanScreen() {
       for (let day = 1; day <= daysInMonth; day++) {
         const date = new Date(year, month, day);
         // Check if there's a workout scheduled for this day of week
-        const hasWorkout = currentPlan.workouts.some(workout => workout.day === date.getDay());
+        const hasWorkout = currentPlan.workouts.some(
+          workout => Number(workout.day) === date.getDay()
+        );
         
         if (hasWorkout) {
           // Format date as YYYY-MM-DD
@@ -59,7 +61,7 @@ export default function PlanScreen() {
     
     // Find workout for the selected day of the week
     return currentPlan.workouts.find(
-      workout => workout.day === selectedDate.getDay()
+      workout => Number(workout.day) === selectedDate.getDay()
     );
   };
   

--- a/app/(tabs)/workout.tsx
+++ b/app/(tabs)/workout.tsx
@@ -16,8 +16,9 @@ export default function WorkoutScreen() {
   
   // Get today's workout if any
   const today = new Date();
+  const todayDay = today.getDay();
   const todayWorkout = currentPlan?.workouts?.find(
-    workout => workout.day === today.getDay()
+    workout => Number(workout.day) === todayDay
   );
   
   // Get last completed workout

--- a/app/workout/session.tsx
+++ b/app/workout/session.tsx
@@ -16,8 +16,9 @@ export default function WorkoutSessionScreen() {
   
   // Get today's workout
   const today = new Date();
+  const todayDay = today.getDay();
   const todayWorkout = currentPlan?.workouts?.find(
-    workout => workout.day === today.getDay()
+    workout => Number(workout.day) === todayDay
   );
   
   const [workoutStarted, setWorkoutStarted] = useState(false);


### PR DESCRIPTION
## Summary
- fix day check to reliably match weekend workouts
- show workout details when scheduled

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684459a42ed483278ec06fd95832ac8a