### PR TITLE
Fix workout day comparison

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -18,9 +18,20 @@ export default function HomeScreen() {
 
   const today = new Date();
   const todayDay = today.getDay();
-  const todayWorkout = currentPlan?.workouts?.find(
-    workout => Number(workout.day) === todayDay
+
+  console.log('Today getDay():', todayDay);
+  currentPlan?.workouts?.forEach(w =>
+    console.log('Workout day:', w.day, 'type:', typeof w.day)
   );
+
+  const todayWorkout = currentPlan?.workouts?.find(workout => {
+    const match = Number(workout.day) === todayDay;
+    console.log(
+      `Comparing today (${todayDay}) with workout day (${workout.day}) ->`,
+      match
+    );
+    return match;
+  });
 
   const startWorkout = () => {
     router.push('/workout/session');

--- a/stores/workoutStore.ts
+++ b/stores/workoutStore.ts
@@ -53,7 +53,16 @@ interface WorkoutState {
 export const useWorkoutStore = create<WorkoutState>((set) => ({
   currentPlan: null,
   workoutHistory: [],
-  setCurrentPlan: (plan) => set({ currentPlan: plan }),
+  setCurrentPlan: (plan) =>
+    set({
+      currentPlan: {
+        ...plan,
+        workouts: plan.workouts?.map((w) => ({
+          ...w,
+          day: Number(w.day)
+        })) || []
+      }
+    }),
   addWorkoutHistory: (workout) => 
     set((state) => ({
       workoutHistory: [workout, ...state.workoutHistory]


### PR DESCRIPTION
## Summary
- normalize workout day values when saving plans
- log weekday data and comparison in home screen for debugging

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445b1d0580832791f46e78e757b64e