### PR TITLE
Add simple workout plan generator

### DIFF
--- a/app/plan/start.tsx
+++ b/app/plan/start.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'expo-router';
 import { theme } from '@/constants/theme';
 import Button from '@/components/ui/Button';
 import { useWorkoutStore } from '@/stores/workoutStore';
-import { generateWorkoutPlan } from '@/utils/workoutPlanner';
+// Simple template-based generator
+import { generateSimplePlan } from '@/utils/simplePlanGenerator';
 import GoalSelector from '@/components/plan/GoalSelector';
 import LocationSelector from '@/components/plan/LocationSelector';
 import DaysSelector from '@/components/plan/DaysSelector';
@@ -45,9 +46,9 @@ export default function PlanStartScreen() {
   };
   
   const handlePlanSubmit = () => {
-    const plan = generateWorkoutPlan({
+    const plan = generateSimplePlan({
       goal: planData.goal,
-      workoutLocation: planData.location,
+      location: planData.location,
       daysPerWeek: planData.daysPerWeek,
       workoutDuration: planData.sessionDuration,
     });

--- a/utils/simplePlanGenerator.ts
+++ b/utils/simplePlanGenerator.ts
@@ -1,0 +1,212 @@
+import { WorkoutPlan } from '@/stores/workoutStore';
+
+export interface PlanInput {
+  goal: string;
+  location: string;
+  daysPerWeek: number;
+  workoutDuration: number;
+}
+
+// Pre-written templates for quick plan generation
+// Additional goals, locations and durations can be added here
+const templates: Record<string, Record<string, Record<number, Record<number, WorkoutPlan>>>> = {
+  glutes: {
+    home: {
+      3: {
+        30: {
+          id: 'glutes_home_3_30',
+          name: 'Home Glutes Builder',
+          description: '3 day home plan focused on glutes',
+          duration: 4,
+          workouts: [
+            {
+              day: 1,
+              name: 'Glutes & Hamstrings',
+              type: 'Strength',
+              duration: 30,
+              exercises: [
+                { name: 'Glute Bridges', sets: 3, reps: 12 },
+                { name: 'Single Leg Deadlift', sets: 3, reps: 10 },
+              ],
+            },
+            {
+              day: 3,
+              name: 'Glutes & Quads',
+              type: 'Strength',
+              duration: 30,
+              exercises: [
+                { name: 'Squats', sets: 3, reps: 15 },
+                { name: 'Reverse Lunges', sets: 3, reps: 12 },
+              ],
+            },
+            {
+              day: 5,
+              name: 'Glute Burnout',
+              type: 'Strength',
+              duration: 30,
+              exercises: [
+                { name: 'Hip Thrust', sets: 3, reps: 15 },
+                { name: 'Fire Hydrant', sets: 3, reps: 12 },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    gym: {
+      3: {
+        45: {
+          id: 'glutes_gym_3_45',
+          name: 'Gym Glutes Builder',
+          description: '3 day gym plan focused on glutes',
+          duration: 4,
+          workouts: [
+            {
+              day: 1,
+              name: 'Glutes & Hamstrings',
+              type: 'Strength',
+              duration: 45,
+              exercises: [
+                { name: 'Barbell Hip Thrust', sets: 4, reps: 12 },
+                { name: 'Romanian Deadlift', sets: 3, reps: 10 },
+              ],
+            },
+            {
+              day: 3,
+              name: 'Glutes & Quads',
+              type: 'Strength',
+              duration: 45,
+              exercises: [
+                { name: 'Barbell Squat', sets: 4, reps: 8 },
+                { name: 'Leg Press', sets: 3, reps: 12 },
+              ],
+            },
+            {
+              day: 5,
+              name: 'Glute Focus',
+              type: 'Strength',
+              duration: 45,
+              exercises: [
+                { name: 'Cable Kickbacks', sets: 3, reps: 15 },
+                { name: 'Walking Lunges', sets: 3, reps: 12 },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  },
+  fullBody: {
+    home: {
+      3: {
+        30: {
+          id: 'full_home_3_30',
+          name: 'Home Full Body',
+          description: '3 day full body plan at home',
+          duration: 4,
+          workouts: [
+            {
+              day: 1,
+              name: 'Full Body A',
+              type: 'Full Body',
+              duration: 30,
+              exercises: [
+                { name: 'Push-ups', sets: 3, reps: 10 },
+                { name: 'Bodyweight Squats', sets: 3, reps: 15 },
+              ],
+            },
+            {
+              day: 3,
+              name: 'Full Body B',
+              type: 'Full Body',
+              duration: 30,
+              exercises: [
+                { name: 'Glute Bridges', sets: 3, reps: 12 },
+                { name: 'Plank', sets: 3, reps: 30 },
+              ],
+            },
+            {
+              day: 5,
+              name: 'Full Body C',
+              type: 'Full Body',
+              duration: 30,
+              exercises: [
+                { name: 'Resistance Band Row', sets: 3, reps: 12 },
+                { name: 'Lunges', sets: 3, reps: 12 },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    gym: {
+      3: {
+        45: {
+          id: 'full_gym_3_45',
+          name: 'Gym Full Body',
+          description: '3 day full body plan at the gym',
+          duration: 4,
+          workouts: [
+            {
+              day: 1,
+              name: 'Full Body A',
+              type: 'Full Body',
+              duration: 45,
+              exercises: [
+                { name: 'Dumbbell Bench Press', sets: 3, reps: 10 },
+                { name: 'Leg Press', sets: 3, reps: 12 },
+              ],
+            },
+            {
+              day: 3,
+              name: 'Full Body B',
+              type: 'Full Body',
+              duration: 45,
+              exercises: [
+                { name: 'Seated Row', sets: 3, reps: 12 },
+                { name: 'Goblet Squat', sets: 3, reps: 12 },
+              ],
+            },
+            {
+              day: 5,
+              name: 'Full Body C',
+              type: 'Full Body',
+              duration: 45,
+              exercises: [
+                { name: 'Lat Pulldown', sets: 3, reps: 12 },
+                { name: 'Walking Lunges', sets: 3, reps: 12 },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+const defaultPlan: WorkoutPlan = {
+  id: 'default',
+  name: 'Quick Start',
+  description: 'Default 3 day plan',
+  duration: 4,
+  workouts: [
+    {
+      day: 1,
+      name: 'Quick Workout',
+      type: 'Full Body',
+      duration: 30,
+      exercises: [
+        { name: 'Push-ups', sets: 3, reps: 10 },
+        { name: 'Squats', sets: 3, reps: 15 },
+      ],
+    },
+  ],
+};
+
+export function generateSimplePlan(input: PlanInput): WorkoutPlan {
+  const { goal, location, daysPerWeek, workoutDuration } = input;
+  return (
+    templates[goal]?.[location]?.[daysPerWeek]?.[workoutDuration] || defaultPlan
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `generateSimplePlan` for template-based plans
- use new generator when creating a workout plan

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445d6c2b8c83279dfc9968f4bca6dd