### PR TITLE
Add plan persistence

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -94,6 +94,12 @@ export default function HomeScreen() {
               total={totalWorkoutsThisWeek}
               totalWorkouts={workoutHistory.length}
             />
+            <Button
+              title="Change My Plan"
+              type="outline"
+              onPress={() => router.push('/plan/start')}
+              style={styles.changePlanButton}
+            />
           </View>
         )}
       </ScrollView>
@@ -150,6 +156,10 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   createButton: {
+    width: '100%',
+  },
+  changePlanButton: {
+    marginTop: 20,
     width: '100%',
   },
   planContainer: {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,14 +17,17 @@ import {
   Montserrat_700Bold
 } from '@expo-google-fonts/montserrat';
 import { useAuthStore } from '@/stores/authStore';
+import { useWorkoutStore } from '@/stores/workoutStore';
+import { loadCurrentPlan } from '@/utils/storage';
 
 // Prevent splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   useFrameworkReady();
-  
+
   const { isAuthenticated } = useAuthStore();
+  const { setCurrentPlan } = useWorkoutStore();
 
   const [fontsLoaded, fontError] = useFonts({
     'Outfit-Regular': Outfit_400Regular,
@@ -43,6 +46,16 @@ export default function RootLayout() {
       SplashScreen.hideAsync();
     }
   }, [fontsLoaded, fontError]);
+
+  // Load saved workout plan on startup
+  useEffect(() => {
+    (async () => {
+      const storedPlan = await loadCurrentPlan();
+      if (storedPlan) {
+        setCurrentPlan(storedPlan);
+      }
+    })();
+  }, []);
 
   // Return null to keep splash screen visible while fonts load
   if (!fontsLoaded && !fontError) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-symbols": "~0.4.3",
     "expo-system-ui": "~5.0.5",
     "expo-web-browser": "~14.1.5",
+    "@react-native-async-storage/async-storage": "^1.21.0",
     "lucide-react-native": "^0.475.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/stores/workoutStore.ts
+++ b/stores/workoutStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { saveCurrentPlan } from '@/utils/storage';
 
 export interface Exercise {
   name: string;
@@ -53,7 +54,8 @@ interface WorkoutState {
 export const useWorkoutStore = create<WorkoutState>((set) => ({
   currentPlan: null,
   workoutHistory: [],
-  setCurrentPlan: (plan) =>
+  setCurrentPlan: (plan) => {
+    saveCurrentPlan(plan);
     set({
       currentPlan: {
         ...plan,
@@ -62,7 +64,8 @@ export const useWorkoutStore = create<WorkoutState>((set) => ({
           day: Number(w.day)
         })) || []
       }
-    }),
+    });
+  },
   addWorkoutHistory: (workout) => 
     set((state) => ({
       workoutHistory: [workout, ...state.workoutHistory]

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import { UserProfile } from '@/stores/userStore';
 
@@ -50,5 +51,51 @@ export async function clearUserProfile(): Promise<void> {
     }
   } catch (error) {
     console.error('Error clearing user profile:', error);
+  }
+}
+
+// Save workout plan to storage
+export async function saveCurrentPlan(plan: any): Promise<void> {
+  try {
+    const jsonValue = JSON.stringify(plan);
+
+    if (Platform.OS === 'web') {
+      localStorage.setItem('tona_current_plan', jsonValue);
+    } else {
+      await AsyncStorage.setItem('tona_current_plan', jsonValue);
+    }
+  } catch (error) {
+    console.error('Error saving workout plan:', error);
+  }
+}
+
+// Load workout plan from storage
+export async function loadCurrentPlan(): Promise<any | null> {
+  try {
+    let jsonValue;
+
+    if (Platform.OS === 'web') {
+      jsonValue = localStorage.getItem('tona_current_plan');
+    } else {
+      jsonValue = await AsyncStorage.getItem('tona_current_plan');
+    }
+
+    return jsonValue != null ? JSON.parse(jsonValue) : null;
+  } catch (error) {
+    console.error('Error loading workout plan:', error);
+    return null;
+  }
+}
+
+// Clear workout plan from storage
+export async function clearCurrentPlan(): Promise<void> {
+  try {
+    if (Platform.OS === 'web') {
+      localStorage.removeItem('tona_current_plan');
+    } else {
+      await AsyncStorage.removeItem('tona_current_plan');
+    }
+  } catch (error) {
+    console.error('Error clearing workout plan:', error);
   }
 }


### PR DESCRIPTION
## Summary
- persist workout plan selection in AsyncStorage
- restore saved plan when the app starts
- allow changing the plan from Home

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844615648208327851d0ef150feeaf9