### PR TITLE
Add workout ids and focus

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -112,7 +112,7 @@ export default function HomeScreen() {
                   onPress={() =>
                     router.push({
                       pathname: '/workout/session',
-                      params: { id: index.toString() }
+                      params: { id: item.workout.id }
                     })
                   }
                 />

--- a/app/workout/session.tsx
+++ b/app/workout/session.tsx
@@ -31,13 +31,13 @@ export default function WorkoutSessionScreen() {
   const nextIndex = completedThisWeek.length + skippedCount;
 
   const params = useLocalSearchParams<{ id?: string }>();
-  const paramIndex = params?.id ? parseInt(Array.isArray(params.id) ? params.id[0] : params.id, 10) : NaN;
-  const selectedIndex = !isNaN(paramIndex) ? paramIndex : nextIndex;
+  const paramId = params?.id ? (Array.isArray(params.id) ? params.id[0] : params.id) : undefined;
 
-  const selectedWorkout =
-    currentPlan?.workouts && selectedIndex < currentPlan.workouts.length
-      ? currentPlan.workouts[selectedIndex]
-      : null;
+  const selectedWorkout = paramId
+    ? currentPlan?.workouts?.find(w => w.id === paramId) || null
+    : currentPlan?.workouts && nextIndex < currentPlan.workouts.length
+    ? currentPlan.workouts[nextIndex]
+    : null;
   
   const [workoutStarted, setWorkoutStarted] = useState(false);
   const [workoutCompleted, setWorkoutCompleted] = useState(false);
@@ -184,7 +184,7 @@ export default function WorkoutSessionScreen() {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.noWorkoutContainer}>
-          <Text style={styles.noWorkoutText}>No workouts left for this week.</Text>
+          <Text style={styles.noWorkoutText}>Workout not found.</Text>
           <Button
             title="Go Back"
             onPress={() => router.back()}

--- a/stores/workoutStore.ts
+++ b/stores/workoutStore.ts
@@ -10,9 +10,11 @@ export interface Exercise {
 }
 
 export interface Workout {
+  id: string;
   day: number; // 0-6 for day of week
   name: string;
   type: string;
+  focus: string;
   duration?: number;
   exercises: Exercise[];
 }

--- a/utils/simplePlanGenerator.ts
+++ b/utils/simplePlanGenerator.ts
@@ -205,8 +205,29 @@ const defaultPlan: WorkoutPlan = {
 
 export function generateSimplePlan(input: PlanInput): WorkoutPlan {
   const { goal, location, daysPerWeek, workoutDuration } = input;
-  return (
-    templates[goal]?.[location]?.[daysPerWeek]?.[workoutDuration] || defaultPlan
-  );
+  const plan =
+    templates[goal]?.[location]?.[daysPerWeek]?.[workoutDuration] || defaultPlan;
+
+  const planId = plan.id || Date.now().toString();
+  return {
+    ...plan,
+    id: planId,
+    workouts: plan.workouts.map((w, idx) => {
+      let focus = 'Full Body';
+      const type = w.type.toLowerCase();
+      if (type.includes('glute')) focus = 'Glutes';
+      else if (type.includes('upper')) focus = 'Upper Body';
+      else if (type.includes('lower')) focus = 'Lower Body';
+      else if (type.includes('push')) focus = 'Push';
+      else if (type.includes('pull')) focus = 'Pull';
+      else if (type.includes('leg')) focus = 'Legs';
+
+      return {
+        ...w,
+        id: `${planId}_${idx}`,
+        focus,
+      };
+    }),
+  };
 }
 

--- a/utils/workoutPlanner.ts
+++ b/utils/workoutPlanner.ts
@@ -274,6 +274,7 @@ export function generateWorkoutPlan(userProfile: UserProfile): WorkoutPlan {
   })();
   
   // Generate workouts for each day
+  const planId = Date.now().toString();
   const workouts: Workout[] = workoutDays.map((day, index) => {
     const workoutName = workoutTypes[index];
     const exerciseCategory = workoutCategories[index];
@@ -329,11 +330,22 @@ export function generateWorkoutPlan(userProfile: UserProfile): WorkoutPlan {
       workoutExercises = [...workoutExercises, ...extra];
     }
     
+    // Determine focus area
+    let focus = 'Full Body';
+    if (workoutName.toLowerCase().includes('glute')) focus = 'Glutes';
+    else if (exerciseCategory === 'upper') focus = 'Upper Body';
+    else if (exerciseCategory === 'lower') focus = 'Lower Body';
+    else if (['push', 'pull', 'legs'].includes(exerciseCategory)) {
+      focus = capitalizeFirstLetter(exerciseCategory);
+    }
+
     // Create the workout
     return {
+      id: `${planId}_${index}`,
       day,
       name: `${workoutTypes[index]} Workout`,
       type: workoutTypes[index],
+      focus,
       duration: userProfile.workoutDuration,
       exercises: workoutExercises,
     };


### PR DESCRIPTION
## Summary
- include id and focus in workout type
- generate focus and ids when creating workout plans
- add helper for simple plan generator to set id and focus
- push workout.id to session screen from home screen
- load workout by id in session screen and show fallback

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: TS errors in utils/workoutPlanner.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6845a11a452483278682e0252dc90e39