### PR TITLE
Add GPT workout plan generator

### DIFF
--- a/utils/gptPlanService.ts
+++ b/utils/gptPlanService.ts
@@ -1,0 +1,44 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+/**
+ * Generate a personalized workout plan using GPT-3.5.
+ * @param goal Desired fitness goal
+ * @param level Experience level
+ * @param days Number of workout days per week
+ */
+export async function generatePlan(
+  goal: string,
+  level: string,
+  days: number
+): Promise<any[]> {
+  const messages = [
+    {
+      role: 'system',
+      content:
+        'You are a helpful fitness coach. Provide the workout plan strictly in JSON format.'
+    },
+    {
+      role: 'user',
+      content: `Create a ${days}-day workout plan for a ${level} level trainee whose goal is ${goal}. Format the response as a JSON array where each item has keys \"day\", \"focus\" and \"exercises\".`
+    }
+  ];
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages,
+    temperature: 0.7
+  });
+
+  const content = completion.choices[0]?.message?.content ?? '';
+
+  try {
+    return JSON.parse(content);
+  } catch (err) {
+    console.error('Failed to parse plan from OpenAI:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- create `utils/gptPlanService.ts` to request a GPT-3.5 workout plan using OpenAI

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*


------
https://chatgpt.com/codex/tasks/task_e_6845a878c92c8327b356712c3d3d2c0a