### PR TITLE
Implement AI workout plan generator

### DIFF
--- a/app/plan/start.tsx
+++ b/app/plan/start.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'expo-router';
 import { theme } from '@/constants/theme';
 import Button from '@/components/ui/Button';
 import { useWorkoutStore } from '@/stores/workoutStore';
-// Simple template-based generator
-import { generateWorkoutPlan } from '@/utils/workoutPlanner';
+// AI-based workout plan generator
+import { generateAIWorkoutPlan } from '@/utils/generateAIWorkoutPlan';
 import GoalSelector from '@/components/plan/GoalSelector';
 import LocationSelector from '@/components/plan/LocationSelector';
 import DaysSelector from '@/components/plan/DaysSelector';
@@ -45,15 +45,19 @@ export default function PlanStartScreen() {
     }
   };
   
-  const handlePlanSubmit = () => {
-    const plan = generateWorkoutPlan({
-      goal: planData.goal,
-      workoutLocation: planData.location as any,
-      daysPerWeek: planData.daysPerWeek,
-      workoutDuration: planData.sessionDuration,
-    });
-    setCurrentPlan(plan);
-    router.replace('/(tabs)');
+  const handlePlanSubmit = async () => {
+    try {
+      const plan = await generateAIWorkoutPlan({
+        goal: planData.goal,
+        workoutLocation: planData.location as any,
+        daysPerWeek: planData.daysPerWeek,
+        workoutDuration: planData.sessionDuration,
+      });
+      setCurrentPlan(plan as any);
+      router.replace('/(tabs)');
+    } catch (error) {
+      console.error('Failed to generate plan:', error);
+    }
   };
   
   const isNextDisabled = () => {

--- a/utils/generateAIWorkoutPlan.ts
+++ b/utils/generateAIWorkoutPlan.ts
@@ -1,0 +1,52 @@
+import { OPENAI_API_KEY } from '@env';
+
+export interface PlanData {
+  goal: string;
+  workoutLocation: string;
+  daysPerWeek: number;
+  workoutDuration: number;
+}
+
+export interface AIWorkout {
+  name: string;
+  targetMuscles: string;
+  description: string;
+}
+
+export interface AIWorkoutPlan {
+  workouts: AIWorkout[];
+  createdAt: string;
+}
+
+export async function generateAIWorkoutPlan(planData: PlanData): Promise<AIWorkoutPlan> {
+  const { goal, workoutLocation, daysPerWeek, workoutDuration } = planData;
+
+  const prompt = `\n  Create a ${goal} workout plan for a woman training ${daysPerWeek} days per week.\n  Each session should be ${workoutDuration} minutes long, to be done at ${workoutLocation}.\n  Please format the output as an array of workouts with the following structure:\n  [\n    {\n      "name": "Workout A",\n      "targetMuscles": "Glutes, Hamstrings",\n      "description": "A lower body workout focusing on glute bridges and RDLs."\n    }\n  ]\n  `;
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.7,
+      }),
+    });
+
+    const data = await res.json();
+    const responseText = data.choices?.[0]?.message?.content || '[]';
+
+    const parsedPlan: AIWorkout[] = JSON.parse(responseText);
+    return {
+      workouts: parsedPlan,
+      createdAt: new Date().toISOString(),
+    };
+  } catch (error) {
+    console.error('AI workout generation failed:', error);
+    throw new Error('Unable to generate workout plan');
+  }
+}


### PR DESCRIPTION
## Summary
- add `generateAIWorkoutPlan` to request plans from OpenAI
- use new async generator when submitting plan

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails with multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae8676e88327a67976a2fd667be7